### PR TITLE
Fix missing basestring on python3

### DIFF
--- a/easywebdav/client.py
+++ b/easywebdav/client.py
@@ -12,6 +12,7 @@ if py_majversion == '2':
 else:
     from http.client import responses as HTTP_CODES
     from urllib.parse import urlparse
+    basestring = str
 
 DOWNLOAD_CHUNK_SIZE_BYTES = 1 * 1024 * 1024
 


### PR DESCRIPTION
python3 lacks the 'basestring' class, instead all strings are unicode and of type 'str'.
this patch makes easywebdav py3-able