### PR TITLE
allow optional HEADERS when uploading files

### DIFF
--- a/easywebdav/client.py
+++ b/easywebdav/client.py
@@ -149,15 +149,15 @@ class Client(object):
     def delete(self, path):
         self._send('DELETE', path, 204)
 
-    def upload(self, local_path_or_fileobj, remote_path):
+    def upload(self, local_path_or_fileobj, remote_path, headers=None):
         if isinstance(local_path_or_fileobj, basestring):
             with open(local_path_or_fileobj, 'rb') as f:
-                self._upload(f, remote_path)
+                self._upload(f, remote_path, headers)
         else:
-            self._upload(local_path_or_fileobj, remote_path)
+            self._upload(local_path_or_fileobj, remote_path, headers)
 
-    def _upload(self, fileobj, remote_path):
-        self._send('PUT', remote_path, (200, 201, 204), data=fileobj)
+    def _upload(self, fileobj, remote_path, headers):
+        self._send('PUT', remote_path, (200, 201, 204), data=fileobj, headers=headers)
 
     def download(self, remote_path, local_path_or_fileobj):
         response = self._send('GET', remote_path, 200, stream=True)


### PR DESCRIPTION
this allows one to override a given mime-type.
e.g. using header={'content-type': 'application/pgp-signature'} allows one
to upload a plain-text signature file with the proper mimetype.

this is important if some WebDAV servers handle files differently based on
the mimetype (e.g. plone)